### PR TITLE
Update branch protection documentation

### DIFF
--- a/docs/developer/branch-protection.md
+++ b/docs/developer/branch-protection.md
@@ -2,19 +2,19 @@
 
 This repository is configured to prevent direct pushes to the main/master branches. This ensures that all changes go through pull requests and code reviews before being merged.
 
-## Automated Setup (GitHub Actions)  czczeqecczs
+## Manual Setup (GitHub Interface)
 
-The repository contains GitHub Actions workflows that set up branch protection rules automatically. For these workflows to work, you need to:
+Branch protection is set up directly through the GitHub web interface:
 
-1. Create a GitHub Personal Access Token (PAT) with the `repo` scope
-2. Add this token as a repository secret named `ADMIN_GITHUB_TOKEN` 
-
-### Creating and Adding the Secret:
-
-1. Go to your GitHub profile settings > Developer settings > Personal access tokens
-2. Generate a new token with the `repo` scope
-3. Navigate to your repository settings > Secrets and variables > Actions
-4. Create a new repository secret named `ADMIN_GITHUB_TOKEN` with the token value
+1. Go to your repository on GitHub
+2. Click on "Settings" > "Branches" (or "Settings" > "Code and automation" > "Branches" in newer interfaces)
+3. Under "Branch protection rules", click "Add rule"
+4. In "Branch name pattern", enter `main` or `master` (depending on your default branch)
+5. Enable the following options:
+   - "Require a pull request before merging"
+   - "Require approvals" (set to 1 or more as needed)
+   - "Dismiss stale pull request approvals when new commits are pushed"
+6. Click "Create" or "Save changes"
 
 After adding the secret, manually trigger the workflows from the "Actions" tab in your repository.
 

--- a/docs/developer/branch-protection.md
+++ b/docs/developer/branch-protection.md
@@ -7,22 +7,6 @@ This repository is configured to prevent direct pushes to the main/master branch
 Branch protection is set up directly through the GitHub web interface:
 
 1. Go to your repository on GitHub
-2. Click on "Settings" > "Branches" (or "Settings" > "Code and automation" > "Branches" in newer interfaces)
-3. Under "Branch protection rules", click "Add rule"
-4. In "Branch name pattern", enter `main` or `master` (depending on your default branch)
-5. Enable the following options:
-   - "Require a pull request before merging"
-   - "Require approvals" (set to 1 or more as needed)
-   - "Dismiss stale pull request approvals when new commits are pushed"
-6. Click "Create" or "Save changes"
-
-After adding the secret, manually trigger the workflows from the "Actions" tab in your repository.
-
-## Manual Setup (GitHub Interface)
-
-You can also set up branch protection rules manually:
-
-1. Go to your repository on GitHub
 2. Click on "Settings" > "Branches"
 3. Under "Branch protection rules", click "Add rule"
 4. In "Branch name pattern", enter `main` or `master` (depending on your default branch)

--- a/docs/developer/branch-protection.md
+++ b/docs/developer/branch-protection.md
@@ -2,7 +2,7 @@
 
 This repository is configured to prevent direct pushes to the main/master branches. This ensures that all changes go through pull requests and code reviews before being merged.
 
-## Automated Setup (GitHub Actions)
+## Automated Setup (GitHub Actions)  czczeqecczs
 
 The repository contains GitHub Actions workflows that set up branch protection rules automatically. For these workflows to work, you need to:
 


### PR DESCRIPTION
Updated the branch protection documentation to reflect that it's now managed through the GitHub web interface rather than configuration files or GitHub Actions workflows.